### PR TITLE
Fix Docker connection error by enabling JavaScript in Chrome startup

### DIFF
--- a/start-chrome.sh
+++ b/start-chrome.sh
@@ -25,7 +25,6 @@ exec google-chrome-stable \
     --disable-extensions \
     --disable-plugins \
     --disable-images \
-    --disable-javascript \
     --virtual-time-budget=5000 \
     --run-all-compositor-stages-before-draw \
     --disable-background-timer-throttling \


### PR DESCRIPTION
## Summary
- Resolves Docker connection error by modifying Chrome startup script
- Removes `--disable-javascript` flag to enable JavaScript in Chrome

## Changes

### Script Update
- **start-chrome.sh**: Removed the `--disable-javascript` flag from the Chrome startup command to allow JavaScript execution, which is necessary for proper WebSocket connections in Docker environment

## Test plan
- [x] Verified Chrome starts without the `--disable-javascript` flag
- [x] Confirmed WebSocket connections work correctly in Docker after the change
- [x] Ensured no other Chrome startup options were affected by this modification

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/97f30f87-0e6c-4154-9bda-d4a8aebe0606