### PR TITLE
Fix nginx proxy connection and enhance WebSocket handling

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -4,8 +4,10 @@ events {
 
 http {
     upstream chrome_debugger {
-        server 127.0.0.1:48333;
+        server 127.0.0.1:48333 max_fails=3 fail_timeout=30s;
         keepalive 32;
+        keepalive_requests 1000;
+        keepalive_timeout 60s;
     }
 
     map $http_upgrade $connection_upgrade {
@@ -33,12 +35,21 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             
-            proxy_connect_timeout 60s;
-            proxy_send_timeout 60s;
-            proxy_read_timeout 60s;
+            # Enhanced timeouts for WebSocket connections
+            proxy_connect_timeout 10s;
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
             
+            # WebSocket specific settings
             proxy_buffering off;
             proxy_cache_bypass $http_upgrade;
+            proxy_redirect off;
+            
+            # Keep connection alive for long-lived WebSocket connections
+            proxy_socket_keepalive on;
+            
+            # Handle connection close properly
+            proxy_set_header Connection "upgrade";
         }
     }
 }


### PR DESCRIPTION
## Summary
- Improved nginx configuration for WebSocket proxy with better timeout and keepalive settings
- Added retry mechanism and readiness check in test-connection.js for more reliable Chrome DevTools connection

## Changes

### nginx.conf
- Added `max_fails` and `fail_timeout` to upstream server for better failure handling
- Configured `keepalive_requests` and `keepalive_timeout` for persistent connections
- Adjusted proxy timeouts: reduced `proxy_connect_timeout` to 10s, increased `proxy_send_timeout` and `proxy_read_timeout` to 300s
- Enabled `proxy_socket_keepalive` and set `proxy_redirect off` for WebSocket stability
- Set `proxy_set_header Connection "upgrade"` explicitly to handle WebSocket connection upgrade

### test-connection.js
- Introduced `connectWithRetry` function to attempt Chrome DevTools connection multiple times with exponential backoff
- Added `waitForChromeReady` function to poll Chrome readiness via nginx before connecting
- Updated `takeScreenshot` to use readiness check and retry connection on port 80 (nginx proxy) instead of direct port 48333

## Test plan
- Verified WebSocket connections remain stable with new nginx settings
- Confirmed retry logic successfully reconnects to Chrome DevTools after transient failures
- Ensured health check and readiness polling work correctly before establishing connection
- Ran existing tests to validate no regressions in screenshot functionality

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/daacf69c-7d26-4f54-a61b-9389ed3e8d02