### PR TITLE
Expose HTTPS port with self-signed SSL in Docker and Nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,13 @@ WORKDIR /app
 # Copy nginx configuration
 COPY nginx.conf /etc/nginx/nginx.conf
 
+# Generate self-signed SSL certificate
+RUN mkdir -p /etc/ssl/certs /etc/ssl/private \
+    && openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+    -keyout /etc/ssl/private/nginx-selfsigned.key \
+    -out /etc/ssl/certs/nginx-selfsigned.crt \
+    -subj "/C=US/ST=State/L=City/O=Organization/CN=localhost"
+
 # Copy and make start script executable
 COPY start-chrome.sh /app/start-chrome.sh
 RUN chmod +x /app/start-chrome.sh
@@ -41,7 +48,7 @@ RUN npm install
 COPY test-connection.js /app/test-connection.js
 
 # Expose ports
-EXPOSE 80 48000-49000
+EXPOSE 80 443 48000-49000
 
 # Set entrypoint
 ENTRYPOINT ["/app/start-chrome.sh"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -52,4 +52,49 @@ http {
             proxy_set_header Connection "upgrade";
         }
     }
+
+    server {
+        listen 443 ssl;
+        server_name _;
+
+        ssl_certificate /etc/ssl/certs/nginx-selfsigned.crt;
+        ssl_certificate_key /etc/ssl/private/nginx-selfsigned.key;
+
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+        ssl_prefer_server_ciphers on;
+
+        location /health {
+            access_log off;
+            return 200 "healthy\n";
+            add_header Content-Type text/plain;
+        }
+
+        location / {
+            proxy_pass http://chrome_debugger;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            
+            # Enhanced timeouts for WebSocket connections
+            proxy_connect_timeout 10s;
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
+            
+            # WebSocket specific settings
+            proxy_buffering off;
+            proxy_cache_bypass $http_upgrade;
+            proxy_redirect off;
+            
+            # Keep connection alive for long-lived WebSocket connections
+            proxy_socket_keepalive on;
+            
+            # Handle connection close properly
+            proxy_set_header Connection "upgrade";
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Adds HTTPS support with a self-signed SSL certificate in the Docker container
- Exposes port 443 alongside existing ports
- Configures Nginx to handle HTTPS traffic with enhanced WebSocket proxy settings

## Changes

### Dockerfile
- Generates a self-signed SSL certificate during build
- Creates necessary directories for SSL cert and key
- Exposes port 443 for HTTPS traffic

### nginx.conf
- Adds a new server block listening on port 443 with SSL enabled
- Uses the self-signed certificate and key generated in Dockerfile
- Configures SSL protocols and ciphers for secure connections
- Adds a `/health` endpoint returning a simple health check response
- Proxies WebSocket connections to the `chrome_debugger` backend with improved timeout and connection handling settings

## Test plan
- Build the Docker image and verify the self-signed certificate is created
- Run the container and confirm port 443 is exposed
- Access the `/health` endpoint over HTTPS and verify a 200 response with "healthy" message
- Test WebSocket connections through the HTTPS proxy to ensure stability and proper upgrade handling

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d152c92b-a8ef-4d44-b49b-09adf4dbc4dd